### PR TITLE
Make top bar more mobile friendly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4324,6 +4324,12 @@
         "timsort": "^0.3.0"
       }
     },
+    "css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
+      "dev": true
+    },
     "css-modules-loader-core": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.3.0",
     "babel-preset-nano-react-app": "^0.1.0",
+    "css-mediaquery": "^0.1.2",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-flowtype": "^5.2.0",

--- a/src/Components/TopBar.tsx
+++ b/src/Components/TopBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { bindActionCreators, Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import { useRouteMatch, useHistory } from 'react-router-dom';
@@ -13,8 +13,19 @@ import {
   IconButton,
   Tooltip,
   useMediaQuery,
+  Hidden,
+  Drawer,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
 } from '@material-ui/core';
-import { InvertColors, Settings, GitHub, Home } from '@material-ui/icons';
+import {
+  InvertColors,
+  Settings,
+  GitHub,
+  Home,
+  ExpandMore,
+} from '@material-ui/icons';
 
 import { StateType } from '../Reducers/main';
 import { setDarkMode } from '../Utils/actionCreators';
@@ -64,6 +75,8 @@ export const TopBar = ({
   const isSettingsActive = useRouteMatch('/settings');
   const downXs = useMediaQuery(getDownQuery('xs'));
 
+  const [menuOpen, setMenuOpen] = useState(false);
+
   useEffect(() => {
     window.document.title = title;
   }, [title]);
@@ -78,6 +91,31 @@ export const TopBar = ({
   const settingsLinkView = isSettingsActive ? 'home' : 'settings';
   const settingsLinkIcon = isSettingsActive ? <Home /> : <Settings />;
 
+  const menuItems = [
+    {
+      text: 'Open GitHub repository',
+      onClick: () => {
+        window.open('https://github.com/kangasta/fdbk-data-display', '_blank');
+      },
+      icon: <GitHub />,
+      testid: 'github-open-button',
+    },
+    {
+      text: `Open ${settingsLinkView}`,
+      onClick: () => history.push(settingsLinkTarget),
+      icon: settingsLinkIcon,
+      testid: 'settings-view-toggle-button',
+    },
+    {
+      text: 'Toggle dark mode',
+      onClick: toggleDarkMode,
+      icon: <InvertColors />,
+      testid: 'darkmode-toggle-button',
+      className: invertColorsClasses,
+      edge: (hasAuthentication ? false : 'end') as false | 'end',
+    },
+  ];
+
   return (
     <AppBar className={classes.appBar} position="static">
       <PageContainer>
@@ -90,37 +128,58 @@ export const TopBar = ({
           >
             {title}
           </Typography>
-          <Tooltip title="Open GitHub repository">
+          <Hidden xsDown>
+            {menuItems.map(({ text, onClick, icon, testid, ...props }) => (
+              <Tooltip key={testid} title={text}>
+                <IconButton
+                  color="inherit"
+                  onClick={onClick}
+                  data-testid={testid}
+                  {...props}
+                >
+                  {icon}
+                </IconButton>
+              </Tooltip>
+            ))}
+          </Hidden>
+          <Hidden smUp>
             <IconButton
-              color="inherit"
-              component="a"
-              href="https://github.com/kangasta/fdbk-data-display"
-              target="_blank"
-            >
-              <GitHub />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title={`Open ${settingsLinkView}`}>
-            <IconButton
-              color="inherit"
-              onClick={() => history.push(settingsLinkTarget)}
-              data-testid="settings-view-toggle-button"
-            >
-              {settingsLinkIcon}
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Toggle dark mode">
-            <IconButton
-              className={invertColorsClasses}
-              onClick={toggleDarkMode}
+              onClick={() => setMenuOpen(true)}
               color="inherit"
               edge={hasAuthentication ? false : 'end'}
-              data-testid="darkmode-toggle-button"
+              data-testid="menu-toggle-button"
             >
-              <InvertColors />
+              <ExpandMore />
             </IconButton>
-          </Tooltip>
+          </Hidden>
           <AccountContainer />
+          <Drawer
+            anchor="top"
+            open={menuOpen}
+            onClose={() => setMenuOpen(false)}
+          >
+            {menuItems.map(({ text, onClick, icon, testid }) => (
+              <ListItem
+                button
+                onClick={() => {
+                  onClick();
+                  setMenuOpen(false);
+                }}
+                key={testid}
+              >
+                <ListItemIcon>{icon}</ListItemIcon>
+                <ListItemText primary={text} />
+              </ListItem>
+            ))}
+            {/* <List>
+              {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
+                <ListItem button key={text}>
+                  <ListItemIcon>{index % 2 === 0 ? <InboxIcon /> : <MailIcon />}</ListItemIcon>
+                  <ListItemText primary={text} />
+                </ListItem>
+              ))}
+            </List> */}
+          </Drawer>
         </Toolbar>
       </PageContainer>
     </AppBar>

--- a/src/Utils/AuthenticationLinks.tsx
+++ b/src/Utils/AuthenticationLinks.tsx
@@ -32,6 +32,6 @@ export const LogIn = ({ authUrl, clientId }: LinkProps) => (
 
 export const LogOut = ({ authUrl, clientId }: LinkProps) => (
   <Link color="inherit" href={getLogoutUrl(authUrl, clientId)}>
-    log out
+    Log out
   </Link>
 );

--- a/src/__tests__/Components/AccountContainer.test.tsx
+++ b/src/__tests__/Components/AccountContainer.test.tsx
@@ -1,25 +1,36 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { ThemeProvider, createMuiTheme } from '@material-ui/core';
 
 import { TEST_ID_NAME, TEST_ID_TOKEN } from '../../setupTests';
 import { AccountContainer } from '../../Components/AccountContainer';
 
+const testTheme = createMuiTheme();
+
 describe('AccountContainer', (): void => {
-  it('displays users name when user is logged in (given_name family_name)', (): void => {
-    const { container } = render(
-      <AccountContainer
-        authUrl="http://auth"
-        clientId="id"
-        idToken={TEST_ID_TOKEN}
-      />
+  it('displays users name when user is logged in (given_name family_name)', async (): Promise<
+    any
+  > => {
+    const { container, findByText, findByTestId } = render(
+      <ThemeProvider theme={testTheme}>
+        <AccountContainer
+          authUrl="http://auth"
+          clientId="id"
+          idToken={TEST_ID_TOKEN}
+        />
+      </ThemeProvider>
     );
 
     expect(container.textContent).toContain(TEST_ID_NAME);
-    expect(container.textContent).toContain('log out');
+    fireEvent.click(await findByTestId('account-menu-button'));
+    await findByText('Log out');
   });
   it('displays log in link when no active logins', (): void => {
     const { queryByText } = render(
-      <AccountContainer authUrl="http://auth" clientId="id" />
+      <ThemeProvider theme={testTheme}>
+        <AccountContainer authUrl="http://auth" clientId="id" />
+      </ThemeProvider>
     );
 
     expect(queryByText('Log in')).toBeInTheDocument();

--- a/src/__tests__/Utils/AuthenticationLinks.test.tsx
+++ b/src/__tests__/Utils/AuthenticationLinks.test.tsx
@@ -30,7 +30,7 @@ describe('LogIn and LogOut', (): void => {
   });
   it.each([
     ['LogIn', 'Log in', LogIn, getLoginUrl],
-    ['LogOut', 'log out', LogOut, getLogoutUrl],
+    ['LogOut', 'Log out', LogOut, getLogoutUrl],
   ])('%s has correct link with %s text', (_, text, CUT, helper): void => {
     const { queryByText } = render(<CUT authUrl="http://auth" clientId="id" />);
     expect(queryByText(text)).toBeInTheDocument();

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,18 @@
 import '@testing-library/jest-dom/extend-expect';
 import { enableFetchMocks } from 'jest-fetch-mock';
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import mediaQuery from 'css-mediaquery';
+
+const createMatchMedia = (width: any): any => {
+  return (query: any) => ({
+    matches: mediaQuery.match(query, { width }),
+    addListener: () => undefined,
+    removeListener: () => undefined,
+  });
+};
+
 enableFetchMocks();
 
 // Fail tests on any warning
@@ -8,6 +20,10 @@ enableFetchMocks();
 console.error = (message: string): void => {
   throw new Error(message);
 };
+
+beforeAll(() => {
+  window.matchMedia = createMatchMedia(window.innerWidth);
+});
 
 // Clear mocks for each test
 beforeEach(() => {


### PR DESCRIPTION
Move icons to a menu on XS screens. Move Log out link into a pop-up menu. Only display given_name on XS screens.

Fixes #9 